### PR TITLE
[feature] video: support v4l2 kernel timestamps

### DIFF
--- a/io/applications/video-cat.cpp
+++ b/io/applications/video-cat.cpp
@@ -62,6 +62,8 @@ output options
     --output-header-format,--output-format
     --output-no-header,--no-header; do not output header
     --output-header-only,--header-only; output header only, e.g. for debugging
+    --use-v4l2-time; use v4l2 assigned timestamp (converted to system time) instead of tagging
+        with system time in userspace
 examples
     acquire and display video stream from a FLIR 16-bit greyscale camera
         porcelain
@@ -269,6 +271,24 @@ int main( int ac, char** av )
                                                                , [&]( const record_t& record )
                                                                  {
                                                                      if( !record ) { return; }
+                                                                     static bool warning_printed = false;
+                                                                     if( !warning_printed )
+                                                                     {
+                                                                         typedef snark::io::video::stream::timestamp_strategy timestamp_strategy;
+                                                                         timestamp_strategy timestamp_source = video.time_strategy();
+                                                                         switch( timestamp_source )
+                                                                         {
+                                                                             case timestamp_strategy::epoch:
+                                                                                 comma::saymore() << "warning: V4L2 timestamp type UNKNOWN; using kernel-provided value as wall time" << std::endl;
+                                                                                 break;
+                                                                             case timestamp_strategy::userspace_fallback:
+                                                                                 comma::saymore() << "warning: V4L2 timestamp type COPY; ignoring kernel value and using host system time" << std::endl;
+                                                                                 break;
+                                                                             default:
+                                                                                 break;
+                                                                         }
+                                                                         warning_printed = true;
+                                                                     }
                                                                      unsigned int c{count};
                                                                      int d = c - record.count;
                                                                      if( latest ) // todo? don't skip, just jump straight to the latest record

--- a/io/video.cpp
+++ b/io/video.cpp
@@ -4,6 +4,8 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <comma/base/exception.h>
+#include <comma/timing/epoch.h>
+#include <comma/timing/kernel.h>
 #include "video.h"
 
 namespace snark { namespace io { namespace video {
@@ -15,15 +17,17 @@ static int xioctl( int fd, int request, void* arg )
     return r;
 }
 
-stream::stream( const std::string& name, unsigned int width, unsigned int height, unsigned int number_of_buffers, int pixel_format )
+stream::stream( const std::string& name, unsigned int width, unsigned int height, unsigned int number_of_buffers, int pixel_format, bool use_v4l2_time )
     : _name( name )
     , _width( width )
     , _height( height )
     , _buffers( number_of_buffers )
+    , _use_v4l2_time( use_v4l2_time )
 {
     _file = std::fopen( &name[0], "r+" );
     COMMA_ASSERT( _file, "failed to open '" << name << "'" );
     _fd = ::fileno( _file );
+    if(!_use_v4l2_time) { _time_strategy = timestamp_strategy::userspace_explicit; }
     v4l2_capability capability{};
     v4l2_format format{};
     format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -116,7 +120,49 @@ stream::record stream::read( float timeout_seconds, unsigned int attempts )
         COMMA_ASSERT( buffer.index < _buffers.size(), "'" << _name << "': expected buffer index less than number of buffers (" << _buffers.size() << "); got: " << buffer.index );
         COMMA_ASSERT( xioctl( _fd, VIDIOC_QBUF, &buffer ) != -1, "'" << _name << "': ioctl error: VIDIOC_QBUF" );
         _index = buffer.index;
-        _buffers[_index].t = boost::posix_time::microsec_clock::universal_time();
+        if( _use_v4l2_time )
+        {
+            if( _time_strategy == timestamp_strategy::unset )
+            {
+                uint32_t timestamp_type = buffer.flags & V4L2_BUF_FLAG_TIMESTAMP_MASK;
+                switch( timestamp_type )
+                {
+                    // Standard modern V4L2 behavior
+                    case V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC:
+                        _time_strategy = timestamp_strategy::monotonic;
+                        break;
+                    // Legacy drivers use CLOCK_REALTIME (epoch)
+                    // Note: Subject to NTP adjustments.
+                    case V4L2_BUF_FLAG_TIMESTAMP_UNKNOWN:
+                        _time_strategy = timestamp_strategy::epoch;
+                        break;
+                    // Timestamp was copied from some other source. Unknown conversion to
+                    // system time so fallback to userspace time to be safe
+                    case V4L2_BUF_FLAG_TIMESTAMP_COPY:
+                    default:
+                        _time_strategy = timestamp_strategy::userspace_fallback;
+                        break;
+                }
+            }
+
+            if( _time_strategy == timestamp_strategy::monotonic )
+            {
+                static const boost::posix_time::ptime boot_time = comma::timing::kernel::boot_time();
+                _buffers[_index].t = boot_time + boost::posix_time::seconds( buffer.timestamp.tv_sec ) + boost::posix_time::microseconds( buffer.timestamp.tv_usec );
+            }
+            else if( _time_strategy == timestamp_strategy::epoch )
+            {
+                _buffers[_index].t = comma::timing::epoch_time() + boost::posix_time::seconds( buffer.timestamp.tv_sec ) + boost::posix_time::microseconds( buffer.timestamp.tv_usec );
+            }
+            else
+            {
+                _buffers[_index].t = boost::posix_time::microsec_clock::universal_time();
+            }
+        }
+        else
+        {
+            _buffers[_index].t = boost::posix_time::microsec_clock::universal_time();
+        }
         return stream::record( ++_count, _buffers[_index] );
     }
 }

--- a/io/video.h
+++ b/io/video.h
@@ -25,7 +25,16 @@ class stream
             record( std::uint32_t count, const snark::timestamped< void* >& buffer ): count( count ), buffer( buffer ) {}
             operator bool() const { return buffer.data != nullptr; }
         };
-        stream( const std::string& name, unsigned int width, unsigned int height, unsigned int number_of_buffers, int pixel_format = V4L2_PIX_FMT_Y16 );
+        enum class timestamp_strategy
+        {
+            unset = 0,
+            monotonic,
+            epoch,
+            userspace_fallback,
+            userspace_explicit
+        };
+
+        stream( const std::string& name, unsigned int width, unsigned int height, unsigned int number_of_buffers, int pixel_format = V4L2_PIX_FMT_Y16, bool use_v4l2_time = false );
         ~stream();
         const unsigned int width() const { return _width; }
         const unsigned int height() const { return _height; }
@@ -34,6 +43,7 @@ class stream
         void stop();
         record read( float timeout = 1, unsigned int attempts = 1 );
         const std::vector< snark::timestamped< void* > >& buffers() const { return _buffers; }
+        timestamp_strategy time_strategy() const { return _time_strategy; }
 
     private:
         std::string _name;
@@ -46,6 +56,8 @@ class stream
         unsigned int _index{0};
         unsigned int _count{0};
         bool _started{false};
+        const bool _use_v4l2_time;
+        timestamp_strategy _time_strategy{timestamp_strategy::unset};
 
 };
 


### PR DESCRIPTION
Provides an option to use driver-assigned timestamps instead of tagging buffers in userspace, reducing timing inaccuries caused by scheduling jitter

   * added --use-v4l2-time flag to video-cat
   * implemented conversion for V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC using kernel boot time
   * added supoort for legacy V4L2_BUF_FLAG_TIMESTAMP_UNKNOWN (assumed epoch time) with a console warning
   * implemented fallback to userspace system time for V4L2_BUF_FLAG_TIMESTAMP_COPY or unrecognized flag states
